### PR TITLE
Support ignored tests

### DIFF
--- a/src/junit.rs
+++ b/src/junit.rs
@@ -59,6 +59,7 @@ impl TestSuite {
             match event {
                 Event::Suite(s) => {
                     match s.event {
+                        EventKind::Ignored => { /* no-op */ },
                         EventKind::Started => {
                             suite.tests = s.test_count.unwrap();
                             counter += 1;
@@ -74,6 +75,7 @@ impl TestSuite {
                 Event::Test(t) => {
                     match t.event {
                         EventKind::Started => { /* no-op */ },
+                        EventKind::Ignored => { /* no-op */ },
                         EventKind::Ok => {
                             suite.test_cases.push(
                                 TestCase {

--- a/src/results.rs
+++ b/src/results.rs
@@ -17,7 +17,8 @@ pub enum ItemKind {
 pub enum EventKind {
     Started,
     Ok,
-    Failed
+    Failed,
+    Ignored,
 }
 
 #[derive(Deserialize, Debug, Eq, PartialEq)]


### PR DESCRIPTION
We have some individual tests that are marked with `#[ignore]` and suity currently panics on them.

This is a super minimal change to get things working, but doesn't actually do anything with the ignored events.